### PR TITLE
Create a bare Ratpack web server based on the port provided and start it up.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Urban bus routing microservice prototype (Groovy port). Version 0.0.9
+# Urban bus routing microservice prototype (Groovy port). Version 0.1.0
 # =============================================================================
 # A daemon written in Groovy, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Urban bus routing microservice prototype (Groovy port). Version 0.0.9
+# Urban bus routing microservice prototype (Groovy port). Version 0.1.0
 # =============================================================================
 # A daemon written in Groovy, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.
@@ -13,7 +13,7 @@
 
 SERV    = bus/build
 DISTS   = $(SERV)/distributions
-VERSION = 0.0.9
+VERSION = 0.1.0
 
 # Specify flags and other vars here.
 GRADLE_W = ./gradlew

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ ./gradlew clean
 $ ./gradlew compileGroovy
 ...
 $ ./gradlew build && \
-  export TARGET=bus/build VERSION=0.0.9 && \
+  export TARGET=bus/build VERSION=0.1.0 && \
   if [ ! -d ${TARGET}/bus ]; then \
       tar -xf ${TARGET}/distributions/bus-${VERSION}.tar -C ${TARGET} && \
       mv ${TARGET}/bus-${VERSION} ${TARGET}/bus; \

--- a/bus/build.gradle
+++ b/bus/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 
     // JNA (Java Native Access) - as a runtime dependency to Syslog4j.
     implementation 'net.java.dev.jna:jna:5.13.0'
+
+    // Ratpack - to set up and run a Netty-based web server.
+    implementation 'io.ratpack:ratpack-core:1.10.0-milestone-25'
 }
 
 // Apply a specific Java toolchain to ease working on different environments.

--- a/bus/build.gradle
+++ b/bus/build.gradle
@@ -1,7 +1,7 @@
 /*
  * bus/build.gradle
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.0.9
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.0
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.
@@ -68,7 +68,7 @@ jar {
 -----------------------------------------------------------------------------*/
 
 group       = 'com.transroutownish.proto'
-version     = '0.0.9'
+version     = '0.1.0'
 description = 'Urban bus routing microservice prototype.'
 
 // vim:set nu et ts=4 sw=4:

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
@@ -1,7 +1,7 @@
 /*
  * bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.0.9
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.0
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.
@@ -22,7 +22,7 @@ import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
 /**
  * The startup class of the daemon.
  *
- * @version 0.0.9
+ * @version 0.1.0
  * @since   0.0.1
  */
 class UrbanBusRoutingApp {

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
@@ -1,5 +1,5 @@
 /*
- * bus/src/main/groovy/bus/UrbanBusRoutingApp.groovy
+ * bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
  * ============================================================================
  * Urban bus routing microservice prototype (Groovy port). Version 0.0.9
  * ============================================================================

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -1,5 +1,6 @@
 /*
- * bus/src/main/groovy/bus/UrbanBusRoutingController.groovy
+ * bus/src/main/groovy/com/transroutownish/proto/bus/
+ * UrbanBusRoutingController.groovy
  * ============================================================================
  * Urban bus routing microservice prototype (Groovy port). Version 0.0.9
  * ============================================================================

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -19,7 +19,9 @@ import org.slf4j.LoggerFactory
 
 import java.lang.invoke.MethodHandles
 
-//import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
+import ratpack.server.RatpackServer
+
+import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
 
 /**
  * The controller class of the daemon.
@@ -28,6 +30,10 @@ import java.lang.invoke.MethodHandles
  * @since   0.0.9
  */
 class UrbanBusRoutingController {
+    // Helper constants.
+    static final String REST_PREFIX = "route"
+    static final String REST_DIRECT = "direct"
+
     /** The SLF4J logger. */
     static final Logger l = LoggerFactory.getLogger(
         MethodHandles.lookup().lookupClass())
@@ -44,25 +50,32 @@ class UrbanBusRoutingController {
         def routes_list       = args[2]
         def s                 = args[3]
 
-//      l.debug "$server_port"
-//      s.debug "$server_port"
-
 //      l.debug "$debug_log_enabled"
 //      s.debug "$debug_log_enabled"
 
 //      l.debug "$routes_list"
 //      s.debug "$routes_list"
 
-/*
-        RatpackServer.of(srvSpec ->
-                         srvSpec.serverConfig(ServerConfig.embedded())
-             .registryOf(regSpec ->
-                         regSpec.add(String.class, EMPTY_STRING))
-               .handlers(chain   ->
-                         chain.get("$REST_PREFIX$SLASH$REST_DIRECT",
-                         ctx     ->
-                         ctx.render(null))
-*/
+        // Creating the Ratpack web server based on the configuration provided.
+        def server = RatpackServer.of(
+            srvSpec     ->
+            srvSpec.serverConfig(
+                srvConf ->
+                srvConf.port(server_port)
+            ).registryOf(
+                regSpec ->
+                regSpec.add(String.class, EMPTY_STRING)
+            ).handlers(
+                chain   ->
+                chain.get("$REST_PREFIX$SLASH$REST_DIRECT",
+                    ctx ->
+                    ctx.render(null)
+                )
+            )
+        )
+
+        // Starting up the Ratpack web server.
+        server.start()
     }
 }
 

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -1,0 +1,68 @@
+/*
+ * bus/src/main/groovy/bus/UrbanBusRoutingController.groovy
+ * ============================================================================
+ * Urban bus routing microservice prototype (Groovy port). Version 0.0.9
+ * ============================================================================
+ * A daemon written in Groovy, designed and intended to be run
+ * as a microservice, implementing a simple urban bus routing prototype.
+ * ============================================================================
+ * Copyright (C) 2023 Radislav (Radicchio) Golubtsov
+ *
+ * (See the LICENSE file at the top of the source tree.)
+ */
+
+package com.transroutownish.proto.bus
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import java.lang.invoke.MethodHandles
+
+//import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
+
+/**
+ * The controller class of the daemon.
+ *
+ * @version 0.0.9
+ * @since   0.0.9
+ */
+class UrbanBusRoutingController {
+    /** The SLF4J logger. */
+    static final Logger l = LoggerFactory.getLogger(
+        MethodHandles.lookup().lookupClass())
+
+    /**
+     * Starts up the bundled web server.
+     *
+     * @param args The list containing the server port number to listen on,
+     *             as the first element.
+     */
+    void startup(final List args) {
+        def server_port       = args[0]
+        def debug_log_enabled = args[1]
+        def routes_list       = args[2]
+        def s                 = args[3]
+
+//      l.debug "$server_port"
+//      s.debug "$server_port"
+
+//      l.debug "$debug_log_enabled"
+//      s.debug "$debug_log_enabled"
+
+//      l.debug "$routes_list"
+//      s.debug "$routes_list"
+
+/*
+        RatpackServer.of(srvSpec ->
+                         srvSpec.serverConfig(ServerConfig.embedded())
+             .registryOf(regSpec ->
+                         regSpec.add(String.class, EMPTY_STRING))
+               .handlers(chain   ->
+                         chain.get("$REST_PREFIX$SLASH$REST_DIRECT",
+                         ctx     ->
+                         ctx.render(null))
+*/
+    }
+}
+
+// vim:set nu et ts=4 sw=4:

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -2,7 +2,7 @@
  * bus/src/main/groovy/com/transroutownish/proto/bus/
  * UrbanBusRoutingController.groovy
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.0.9
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.0
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.
@@ -26,7 +26,7 @@ import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
 /**
  * The controller class of the daemon.
  *
- * @version 0.0.9
+ * @version 0.1.0
  * @since   0.0.9
  */
 class UrbanBusRoutingController {

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -1,5 +1,6 @@
 /*
- * bus/src/main/groovy/bus/UrbanBusRoutingHelper.groovy
+ * bus/src/main/groovy/com/transroutownish/proto/bus/
+ * UrbanBusRoutingHelper.groovy
  * ============================================================================
  * Urban bus routing microservice prototype (Groovy port). Version 0.0.9
  * ============================================================================

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -31,6 +31,7 @@ class UrbanBusRoutingHelper {
     static final int    EXIT_SUCCESS =   0 // Successful exit status.
     static final String EMPTY_STRING =  ""
     static final String SPACE        = " "
+    static final String SLASH        = "/"
 
     // Extra helper constants.
     static final String YES = "yes"

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -2,7 +2,7 @@
  * bus/src/main/groovy/com/transroutownish/proto/bus/
  * UrbanBusRoutingHelper.groovy
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.0.9
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.0
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.
@@ -22,7 +22,7 @@ import java.lang.invoke.MethodHandles
 /**
  * The helper class for the daemon.
  *
- * @version 0.0.9
+ * @version 0.1.0
  * @since   0.0.1
  */
 class UrbanBusRoutingHelper {

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -26,6 +26,8 @@ import java.lang.invoke.MethodHandles
  */
 class UrbanBusRoutingHelper {
     // Helper constants.
+    static final int    EXIT_FAILURE =   1 //    Failing exit status.
+    static final int    EXIT_SUCCESS =   0 // Successful exit status.
     static final String EMPTY_STRING =  ""
     static final String SPACE        = " "
 
@@ -33,6 +35,10 @@ class UrbanBusRoutingHelper {
     static final String YES = "yes"
 
     // Common error messages.
+    static final String ERR_PORT_VALID_MUST_BE_POSITIVE_INT
+        = '''Valid server port must be a positive integer value,\
+ in the range 1024 .. 49151. The default value of 8080\
+ will be used instead.'''
     static final String ERR_APP_PROPS_UNABLE_TO_GET
         = "Unable to get application properties."
     static final String ERR_DATASTORE_NOT_FOUND
@@ -40,6 +46,18 @@ class UrbanBusRoutingHelper {
 
     /** The application properties filename. */
     static final String APP_PROPS = "application.properties"
+
+    /** The minimum port number allowed. */
+    static final int MIN_PORT = 1024
+
+    /** The maximum port number allowed. */
+    static final int MAX_PORT = 49151
+
+    /** The default server port number. */
+    static final int DEF_PORT = 8080
+
+    // Application properties keys for the server port number.
+    static final String SERVER_PORT = "server.port"
 
     // Application properties keys for the logger.
     static final String DEBUG_LOG_ENABLED = "logger.debug.enabled"
@@ -52,6 +70,45 @@ class UrbanBusRoutingHelper {
     /** The SLF4J logger. */
     static final Logger l = LoggerFactory.getLogger(
         MethodHandles.lookup().lookupClass())
+
+    /**
+     * Retrieves the port number used to run the server,
+     * from application properties.
+     *
+     * @return The port number on which the server has to be run.
+     */
+    static int get_server_port() {
+        def server_port_ = UrbanBusRoutingApp.props.getProperty(SERVER_PORT)
+        def server_port  = null
+
+        try { server_port = Integer.parseInt(server_port_) }
+        catch (NumberFormatException e) { /* Using the last `else' block. */ }
+
+        if (server_port !== null) {
+            if ((server_port >= MIN_PORT) && (server_port <= MAX_PORT)) {
+                return server_port
+            } else {
+                l.error ERR_PORT_VALID_MUST_BE_POSITIVE_INT; return DEF_PORT
+            }
+        } else {
+            l.error ERR_PORT_VALID_MUST_BE_POSITIVE_INT; return DEF_PORT
+        }
+    }
+
+    /**
+     * Identifies whether debug logging is enabled by retrieving
+     * the corresponding setting from application properties.
+     *
+     * @return <code>true</code> if debug logging is enabled,
+     *         <code>false</code> otherwise.
+     */
+    static boolean is_debug_log_enabled() {
+        def debug_log_enabled
+            = UrbanBusRoutingApp.props.getProperty(DEBUG_LOG_ENABLED)
+
+        if ((debug_log_enabled !== null)
+            && (debug_log_enabled == YES)) { return true }
+    }
 
     /**
      * Retrieves the path and filename of the routes data store
@@ -74,21 +131,6 @@ class UrbanBusRoutingHelper {
         if (datastore.isEmpty()) { return null }
 
         return datastore
-    }
-
-    /**
-     * Identifies whether debug logging is enabled by retrieving
-     * the corresponding setting from application properties.
-     *
-     * @return <code>true</code> if debug logging is enabled,
-     *         <code>false</code> otherwise.
-     */
-    static boolean is_debug_log_enabled() {
-        def debug_log_enabled
-            = UrbanBusRoutingApp.props.getProperty(DEBUG_LOG_ENABLED)
-
-        if ((debug_log_enabled !== null)
-            && (debug_log_enabled == YES)) { return true }
     }
 
     // Helper method. Used to get the application properties object.

--- a/bus/src/main/resources/application.properties
+++ b/bus/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 #
 # bus/src/main/resources/application.properties
 # =============================================================================
-# Urban bus routing microservice prototype (Groovy port). Version 0.0.9
+# Urban bus routing microservice prototype (Groovy port). Version 0.1.0
 # =============================================================================
 # A daemon written in Groovy, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/bus/src/main/resources/application.properties
+++ b/bus/src/main/resources/application.properties
@@ -11,6 +11,8 @@
 # (See the LICENSE file at the top of the source tree.)
 #
 
+server.port=8765
+
 # Uncomment this setting to enable debug logging.
 #logger.debug.enabled=yes
 

--- a/bus/src/main/resources/log4j.properties
+++ b/bus/src/main/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # bus/src/main/resources/log4j.properties
 # =============================================================================
-# Urban bus routing microservice prototype (Groovy port). Version 0.0.9
+# Urban bus routing microservice prototype (Groovy port). Version 0.1.0
 # =============================================================================
 # A daemon written in Groovy, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 /*
  * settings.gradle
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.0.9
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.0
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.


### PR DESCRIPTION
- Adding a _server port number_ to application properties.
- Introducing the _controller class_ of the daemon.
- Introducing and calling the _helper method to retrieve the port number used to run the server_, from application properties.
- Adding dependency: `ratpack-core`: **Ratpack Core: Netty-based web server and friends**.
- Creating a _bare_ **Ratpack web server** based on the port provided and starting it up.
- Bumping version number to **0.1.0**.