### PR TITLE
Introduce the service class for the daemon to log events of starting/stopping the bundled web server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Urban bus routing microservice prototype (Groovy port). Version 0.1.0
+# Urban bus routing microservice prototype (Groovy port). Version 0.1.2
 # =============================================================================
 # A daemon written in Groovy, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Urban bus routing microservice prototype (Groovy port). Version 0.1.0
+# Urban bus routing microservice prototype (Groovy port). Version 0.1.2
 # =============================================================================
 # A daemon written in Groovy, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.
@@ -13,7 +13,7 @@
 
 SERV    = bus/build
 DISTS   = $(SERV)/distributions
-VERSION = 0.1.0
+VERSION = 0.1.2
 
 # Specify flags and other vars here.
 GRADLE_W = ./gradlew

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ ./gradlew clean
 $ ./gradlew compileGroovy
 ...
 $ ./gradlew build && \
-  export TARGET=bus/build VERSION=0.1.0 && \
+  export TARGET=bus/build VERSION=0.1.2 && \
   if [ ! -d ${TARGET}/bus ]; then \
       tar -xf ${TARGET}/distributions/bus-${VERSION}.tar -C ${TARGET} && \
       mv ${TARGET}/bus-${VERSION} ${TARGET}/bus; \

--- a/bus/build.gradle
+++ b/bus/build.gradle
@@ -1,7 +1,7 @@
 /*
  * bus/build.gradle
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.1.0
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.2
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.
@@ -68,7 +68,7 @@ jar {
 -----------------------------------------------------------------------------*/
 
 group       = 'com.transroutownish.proto'
-version     = '0.1.0'
+version     = '0.1.2'
 description = 'Urban bus routing microservice prototype.'
 
 // vim:set nu et ts=4 sw=4:

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
@@ -101,10 +101,6 @@ class UrbanBusRoutingApp {
             routes_list,
             s // <== The Unix system logger (like in Clojure port).
         ])
-
-        // Closing the system logger.
-        // Calling <syslog.h> closelog();
-        s.shutdown()
     }
 }
 

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
@@ -1,7 +1,7 @@
 /*
  * bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.1.0
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.2
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.
@@ -22,7 +22,7 @@ import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
 /**
  * The startup class of the daemon.
  *
- * @version 0.1.0
+ * @version 0.1.2
  * @since   0.0.1
  */
 class UrbanBusRoutingApp {

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -19,6 +19,12 @@ import org.slf4j.LoggerFactory
 
 import java.lang.invoke.MethodHandles
 
+import org.graylog2.syslog4j.impl.unix.UnixSyslog
+
+import ratpack.service.Service
+import ratpack.service.StartEvent
+import ratpack.service.StopEvent
+
 import ratpack.server.RatpackServer
 
 import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
@@ -39,16 +45,58 @@ class UrbanBusRoutingController {
         MethodHandles.lookup().lookupClass())
 
     /**
+     * The service class for the daemon.
+     * <br />
+     * <br />It is used solely to log events of starting/stopping
+     * the bundled web server.
+     */
+    class UrbanBusRoutingService implements Service {
+        /**
+         * Gets called when the server is about to be started.
+         *
+         * @param event The metadata object containing the startup event info.
+         */
+        void onStart(final StartEvent event) {
+            def registry = event.getRegistry()
+
+            def s = registry.get(UnixSyslog)
+            def server_port = registry.get(Integer)
+
+            l.info "$MSG_SERVER_STARTED$server_port"
+            s.info "$MSG_SERVER_STARTED$server_port"
+        }
+
+        /**
+         * Gets called just before the server is about to be stopped.
+         *
+         * @param event The metadata object containing the stop event info.
+         */
+        void onStop(final StopEvent event) {
+            def registry = event.getRegistry()
+
+            def s = registry.get(UnixSyslog)
+
+            l.info MSG_SERVER_STOPPED
+            s.info MSG_SERVER_STOPPED
+
+            // Closing the system logger.
+            // Calling <syslog.h> closelog();
+            s.shutdown()
+        }
+    }
+
+    /**
      * Starts up the bundled web server.
      *
      * @param args The list containing the server port number to listen on,
      *             as the first element.
      */
     void startup(final List args) {
-        def server_port       = args[0]
-        def debug_log_enabled = args[1]
-        def routes_list       = args[2]
-        def s                 = args[3]
+        def(server_port,
+            debug_log_enabled,
+            routes_list,
+            syslog
+        ) = args
 
 //      l.debug "$debug_log_enabled"
 //      s.debug "$debug_log_enabled"
@@ -56,15 +104,19 @@ class UrbanBusRoutingController {
 //      l.debug "$routes_list"
 //      s.debug "$routes_list"
 
+        def service = new UrbanBusRoutingService()
+
         // Creating the Ratpack web server based on the configuration provided.
         def server = RatpackServer.of(
             srvSpec     ->
             srvSpec.serverConfig(
                 srvConf ->
-                srvConf.port(server_port)
+                srvConf.props(UrbanBusRoutingApp.props)
             ).registryOf(
                 regSpec ->
-                regSpec.add(String.class, EMPTY_STRING)
+                regSpec.add(service)
+                       .add(server_port)
+                       .add(syslog)
             ).handlers(
                 chain   ->
                 chain.get("$REST_PREFIX$SLASH$REST_DIRECT",

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -2,7 +2,7 @@
  * bus/src/main/groovy/com/transroutownish/proto/bus/
  * UrbanBusRoutingController.groovy
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.1.0
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.2
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.
@@ -32,7 +32,7 @@ import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
 /**
  * The controller class of the daemon.
  *
- * @version 0.1.0
+ * @version 0.1.2
  * @since   0.0.9
  */
 class UrbanBusRoutingController {

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -104,8 +104,6 @@ class UrbanBusRoutingController {
 //      l.debug "$routes_list"
 //      s.debug "$routes_list"
 
-        def service = new UrbanBusRoutingService()
-
         // Creating the Ratpack web server based on the configuration provided.
         def server = RatpackServer.of(
             srvSpec     ->
@@ -114,14 +112,14 @@ class UrbanBusRoutingController {
                 srvConf.props(UrbanBusRoutingApp.props)
             ).registryOf(
                 regSpec ->
-                regSpec.add(service)
+                regSpec.add(new UrbanBusRoutingService())
                        .add(server_port)
                        .add(syslog)
             ).handlers(
                 chain   ->
                 chain.get("$REST_PREFIX$SLASH$REST_DIRECT",
                     ctx ->
-                    ctx.render(null)
+                    ctx.render("Not yet implemented.")
                 )
             )
         )

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -46,6 +46,10 @@ class UrbanBusRoutingHelper {
     static final String ERR_DATASTORE_NOT_FOUND
         = "FATAL: Data store file not found. Quitting..."
 
+    // Common notification messages.
+    static final String MSG_SERVER_STARTED = "Server started on port "
+    static final String MSG_SERVER_STOPPED = "Server stopped"
+
     /** The application properties filename. */
     static final String APP_PROPS = "application.properties"
 

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -2,7 +2,7 @@
  * bus/src/main/groovy/com/transroutownish/proto/bus/
  * UrbanBusRoutingHelper.groovy
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.1.0
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.2
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.
@@ -22,7 +22,7 @@ import java.lang.invoke.MethodHandles
 /**
  * The helper class for the daemon.
  *
- * @version 0.1.0
+ * @version 0.1.2
  * @since   0.0.1
  */
 class UrbanBusRoutingHelper {

--- a/bus/src/main/resources/application.properties
+++ b/bus/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 #
 # bus/src/main/resources/application.properties
 # =============================================================================
-# Urban bus routing microservice prototype (Groovy port). Version 0.1.0
+# Urban bus routing microservice prototype (Groovy port). Version 0.1.2
 # =============================================================================
 # A daemon written in Groovy, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/bus/src/main/resources/log4j.properties
+++ b/bus/src/main/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # bus/src/main/resources/log4j.properties
 # =============================================================================
-# Urban bus routing microservice prototype (Groovy port). Version 0.1.0
+# Urban bus routing microservice prototype (Groovy port). Version 0.1.2
 # =============================================================================
 # A daemon written in Groovy, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 /*
  * settings.gradle
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.1.0
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.2
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.


### PR DESCRIPTION
- Adding constants: common notification messages.
- Bringing out closing the system logger action into the controller.
- Introducing the **service class for the daemon**: it is used solely to log events of starting/stopping the bundled web server.
- Making a group assignment a bit more Groovysh &mdash; _multiple assignment_.
- Utilizing the **server registry**: populating it with the server metadata.
- Responding to a client with `HTTP 200 OK` and "**Not yet implemented.**" in `text/plain` for GET requests to `/route/direct`.
- Bumping version number to **0.1.2**.