### PR TITLE
Try to start up the Ratpack web server and report appropriately if errors occurred.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Urban bus routing microservice prototype (Groovy port). Version 0.1.2
+# Urban bus routing microservice prototype (Groovy port). Version 0.1.5
 # =============================================================================
 # A daemon written in Groovy, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Urban bus routing microservice prototype (Groovy port). Version 0.1.2
+# Urban bus routing microservice prototype (Groovy port). Version 0.1.5
 # =============================================================================
 # A daemon written in Groovy, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.
@@ -13,7 +13,7 @@
 
 SERV    = bus/build
 DISTS   = $(SERV)/distributions
-VERSION = 0.1.2
+VERSION = 0.1.5
 
 # Specify flags and other vars here.
 GRADLE_W = ./gradlew

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ ./gradlew clean
 $ ./gradlew compileGroovy
 ...
 $ ./gradlew build && \
-  export TARGET=bus/build VERSION=0.1.2 && \
+  export TARGET=bus/build VERSION=0.1.5 && \
   if [ ! -d ${TARGET}/bus ]; then \
       tar -xf ${TARGET}/distributions/bus-${VERSION}.tar -C ${TARGET} && \
       mv ${TARGET}/bus-${VERSION} ${TARGET}/bus; \

--- a/bus/build.gradle
+++ b/bus/build.gradle
@@ -1,7 +1,7 @@
 /*
  * bus/build.gradle
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.1.2
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.5
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.
@@ -68,7 +68,7 @@ jar {
 -----------------------------------------------------------------------------*/
 
 group       = 'com.transroutownish.proto'
-version     = '0.1.2'
+version     = '0.1.5'
 description = 'Urban bus routing microservice prototype.'
 
 // vim:set nu et ts=4 sw=4:

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
@@ -74,7 +74,7 @@ class UrbanBusRoutingApp {
         try {
             routes = new Scanner(data)
         } catch (FileNotFoundException e) {
-            l.error ERR_DATASTORE_NOT_FOUND
+            l.error(ERR_DATASTORE_NOT_FOUND)
 
             System.exit(EXIT_FAILURE)
         }

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
@@ -1,7 +1,7 @@
 /*
  * bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingApp.groovy
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.1.2
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.5
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.
@@ -22,7 +22,7 @@ import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
 /**
  * The startup class of the daemon.
  *
- * @version 0.1.2
+ * @version 0.1.5
  * @since   0.0.1
  */
 class UrbanBusRoutingApp {

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -27,6 +27,8 @@ import ratpack.service.StopEvent
 
 import ratpack.server.RatpackServer
 
+import ratpack.http.Status
+
 import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
 
 /**
@@ -36,10 +38,6 @@ import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
  * @since   0.0.9
  */
 class UrbanBusRoutingController {
-    // Helper constants.
-    static final String REST_PREFIX = "route"
-    static final String REST_DIRECT = "direct"
-
     /** The SLF4J logger. */
     static final Logger l = LoggerFactory.getLogger(
         MethodHandles.lookup().lookupClass())
@@ -116,10 +114,12 @@ class UrbanBusRoutingController {
                        .add(server_port)
                        .add(syslog)
             ).handlers(
-                chain   ->
+                chain   -> // GET /route/direct
                 chain.get("$REST_PREFIX$SLASH$REST_DIRECT",
                     ctx ->
-                    ctx.render("Not yet implemented.")
+                    ctx.getResponse()
+                       .status(Status.OK)
+                       .send(MIME_TYPE, ERR_NOT_YET_IMPLEMENTED)
                 )
             )
         )

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -2,7 +2,7 @@
  * bus/src/main/groovy/com/transroutownish/proto/bus/
  * UrbanBusRoutingController.groovy
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.1.2
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.5
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.
@@ -34,7 +34,7 @@ import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
 /**
  * The controller class of the daemon.
  *
- * @version 0.1.2
+ * @version 0.1.5
  * @since   0.0.9
  */
 class UrbanBusRoutingController {

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -124,8 +124,12 @@ class UrbanBusRoutingController {
             )
         )
 
-        // Starting up the Ratpack web server.
-        server.start()
+        try {
+            // Starting up the Ratpack web server.
+            server.start()
+        } catch (Exception e) {
+            l.error e.getMessage()
+        }
     }
 }
 

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -60,8 +60,8 @@ class UrbanBusRoutingController {
             def s = registry.get(UnixSyslog)
             def server_port = registry.get(Integer)
 
-            l.info "$MSG_SERVER_STARTED$server_port"
-            s.info "$MSG_SERVER_STARTED$server_port"
+            l.info(MSG_SERVER_STARTED + server_port)
+            s.info(MSG_SERVER_STARTED + server_port)
         }
 
         /**
@@ -74,8 +74,8 @@ class UrbanBusRoutingController {
 
             def s = registry.get(UnixSyslog)
 
-            l.info MSG_SERVER_STOPPED
-            s.info MSG_SERVER_STOPPED
+            l.info(MSG_SERVER_STOPPED)
+            s.info(MSG_SERVER_STOPPED)
 
             // Closing the system logger.
             // Calling <syslog.h> closelog();
@@ -95,12 +95,6 @@ class UrbanBusRoutingController {
             routes_list,
             syslog
         ) = args
-
-//      l.debug "$debug_log_enabled"
-//      s.debug "$debug_log_enabled"
-
-//      l.debug "$routes_list"
-//      s.debug "$routes_list"
 
         // Creating the Ratpack web server based on the configuration provided.
         def server = RatpackServer.of(
@@ -131,9 +125,9 @@ class UrbanBusRoutingController {
             if ((e instanceof io.netty.channel.unix.Errors.NativeIoException)
                 && (e.expectedErr() === ERR_EADDRINUSE_NEGATIVE)) {
 
-                l.error ERR_CANNOT_START_SERVER + ERR_ADDR_ALREADY_IN_USE
+                l.error(ERR_CANNOT_START_SERVER + ERR_ADDR_ALREADY_IN_USE)
             } else {
-                l.error ERR_CANNOT_START_SERVER + ERR_SERV_UNKNOWN_REASON
+                l.error(ERR_CANNOT_START_SERVER + ERR_SERV_UNKNOWN_REASON)
             }
         }
     }

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -124,11 +124,17 @@ class UrbanBusRoutingController {
             )
         )
 
+        // Trying to start up the Ratpack web server.
         try {
-            // Starting up the Ratpack web server.
             server.start()
         } catch (Exception e) {
-            l.error e.getMessage()
+            if ((e instanceof io.netty.channel.unix.Errors.NativeIoException)
+                && (e.expectedErr() === ERR_EADDRINUSE_NEGATIVE)) {
+
+                l.error ERR_CANNOT_START_SERVER + ERR_ADDR_ALREADY_IN_USE
+            } else {
+                l.error ERR_CANNOT_START_SERVER + ERR_SERV_UNKNOWN_REASON
+            }
         }
     }
 }

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -110,10 +110,10 @@ class UrbanBusRoutingHelper {
             if ((server_port >= MIN_PORT) && (server_port <= MAX_PORT)) {
                 return server_port
             } else {
-                l.error ERR_PORT_VALID_MUST_BE_POSITIVE_INT; return DEF_PORT
+                l.error(ERR_PORT_VALID_MUST_BE_POSITIVE_INT); return DEF_PORT
             }
         } else {
-            l.error ERR_PORT_VALID_MUST_BE_POSITIVE_INT; return DEF_PORT
+            l.error(ERR_PORT_VALID_MUST_BE_POSITIVE_INT); return DEF_PORT
         }
     }
 
@@ -167,7 +167,7 @@ class UrbanBusRoutingHelper {
             props.load(data)
             data.close()
         } catch (IOException e) {
-            l.error ERR_APP_PROPS_UNABLE_TO_GET
+            l.error(ERR_APP_PROPS_UNABLE_TO_GET)
         }
 
         return props

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -53,6 +53,7 @@ class UrbanBusRoutingHelper {
         = "for an unknown reason. Quitting..."
     static final String ERR_NOT_YET_IMPLEMENTED
         = '{"error":"Not yet implemented."}'
+    static final int    ERR_EADDRINUSE_NEGATIVE = -98
 
     // Common notification messages.
     static final String MSG_SERVER_STARTED = "Server started on port "

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -2,7 +2,7 @@
  * bus/src/main/groovy/com/transroutownish/proto/bus/
  * UrbanBusRoutingHelper.groovy
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.1.2
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.5
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.
@@ -22,7 +22,7 @@ import java.lang.invoke.MethodHandles
 /**
  * The helper class for the daemon.
  *
- * @version 0.1.2
+ * @version 0.1.5
  * @since   0.0.1
  */
 class UrbanBusRoutingHelper {

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -45,6 +45,12 @@ class UrbanBusRoutingHelper {
         = "Unable to get application properties."
     static final String ERR_DATASTORE_NOT_FOUND
         = "FATAL: Data store file not found. Quitting..."
+    static final String ERR_CANNOT_START_SERVER
+        = "FATAL: Cannot start server "
+    static final String ERR_ADDR_ALREADY_IN_USE
+        = "due to address requested already in use. Quitting..."
+    static final String ERR_SERV_UNKNOWN_REASON
+        = "for an unknown reason. Quitting..."
     static final String ERR_NOT_YET_IMPLEMENTED
         = '{"error":"Not yet implemented."}'
 

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -45,6 +45,8 @@ class UrbanBusRoutingHelper {
         = "Unable to get application properties."
     static final String ERR_DATASTORE_NOT_FOUND
         = "FATAL: Data store file not found. Quitting..."
+    static final String ERR_NOT_YET_IMPLEMENTED
+        = '{"error":"Not yet implemented."}'
 
     // Common notification messages.
     static final String MSG_SERVER_STARTED = "Server started on port "
@@ -72,6 +74,13 @@ class UrbanBusRoutingHelper {
     static final String PATH_PREFIX = "routes.datastore.path.prefix"
     static final String PATH_DIR    = "routes.datastore.path.dir"
     static final String FILENAME    = "routes.datastore.filename"
+
+    // REST URI path-related constants.
+    static final String REST_PREFIX = "route"
+    static final String REST_DIRECT = "direct"
+
+    // HTTP response-related constants.
+    static final String MIME_TYPE = "application/json"
 
     /** The SLF4J logger. */
     static final Logger l = LoggerFactory.getLogger(

--- a/bus/src/main/resources/application.properties
+++ b/bus/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 #
 # bus/src/main/resources/application.properties
 # =============================================================================
-# Urban bus routing microservice prototype (Groovy port). Version 0.1.2
+# Urban bus routing microservice prototype (Groovy port). Version 0.1.5
 # =============================================================================
 # A daemon written in Groovy, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/bus/src/main/resources/log4j.properties
+++ b/bus/src/main/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # bus/src/main/resources/log4j.properties
 # =============================================================================
-# Urban bus routing microservice prototype (Groovy port). Version 0.1.2
+# Urban bus routing microservice prototype (Groovy port). Version 0.1.5
 # =============================================================================
 # A daemon written in Groovy, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 /*
  * settings.gradle
  * ============================================================================
- * Urban bus routing microservice prototype (Groovy port). Version 0.1.2
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.5
  * ============================================================================
  * A daemon written in Groovy, designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.


### PR DESCRIPTION
- Adding various request- and response-related constants.
- Sending a dummy response in `application/json` instead of plain text.
- Adding common error messages &mdash; to notify when the server cannot be started.
- Adding constant: The negative numerical value of the socket error "Address already in use".
- Trying to start up the **Ratpack web server** and reporting appropriately if errors occurred.
- Making logging code a bit more _Javish_ or _C-ish_.
- Bumping version number to **0.1.5**.