### PR TITLE
Send responses in JSON using the Jackson facility.

### DIFF
--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -174,12 +174,15 @@ class UrbanBusRoutingController {
                 chain   -> // GET /route/direct
                 chain.get("$REST_PREFIX$SLASH$REST_DIRECT",
                     ctx ->
-                    ctx.getResponse()
-                       .status(Status.OK)
-                       .send(MIME_TYPE, ERR_NOT_YET_IMPLEMENTED)
-                )
-            )
-        )
+//                  ctx.getResponse()
+//                     .status(Status.OK)
+//                     .send(MIME_TYPE, ERR_NOT_YET_IMPLEMENTED)
+                    ctx.render(Jackson.json(
+                        new UrbanBusRoutingResponseOk(0, 0, false)
+                    ))  //                            ^  ^  ^
+                )       // from ----------------------+  |  |
+            )           // to ---------------------------+  |
+        )               // direct --------------------------+
 
         // Trying to start up the Ratpack web server.
         try {

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingController.groovy
@@ -31,6 +31,8 @@ import ratpack.handling.Context
 
 import ratpack.http.Status
 
+import ratpack.jackson.Jackson
+
 import ratpack.server.RatpackServer
 
 import static com.transroutownish.proto.bus.UrbanBusRoutingHelper.*
@@ -131,7 +133,15 @@ class UrbanBusRoutingController {
 
             l.debug(uri)
 
-            ctx.getResponse().status(status).send(MIME_TYPE, body)
+            def resp = ctx.getResponse().status(status)
+
+            if (body.isEmpty()) {
+                resp.send(MIME_TYPE, body)
+            } else {
+                ctx.render(Jackson.json(
+                    new UrbanBusRoutingResponseError(body)
+                ))
+            }
         }
     }
 

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -51,8 +51,6 @@ class UrbanBusRoutingHelper {
         = "due to address requested already in use. Quitting..."
     static final String ERR_SERV_UNKNOWN_REASON
         = "for an unknown reason. Quitting..."
-    static final String ERR_NOT_YET_IMPLEMENTED
-        = '{"error":"Not yet implemented."}'
     static final String ERR_REQ_PARAMS_MUST_BE_POSITIVE_INTS
         = '''Request parameters must take positive integer values,\
  in the range 1 .. 2,147,483,647. Please check your inputs.'''

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingHelper.groovy
@@ -54,10 +54,10 @@ class UrbanBusRoutingHelper {
     static final String ERR_NOT_YET_IMPLEMENTED
         = '{"error":"Not yet implemented."}'
     static final String ERR_REQ_PARAMS_MUST_BE_POSITIVE_INTS
-        = '''{"error":"Request parameters must take positive integer values,\
- in the range 1 .. 2,147,483,647. Please check your inputs."}'''
+        = '''Request parameters must take positive integer values,\
+ in the range 1 .. 2,147,483,647. Please check your inputs.'''
     static final String ERR_NOT_FOUND
-        = '{"error":"404 Not Found."}'
+        = "404 Not Found."
     static final int    ERR_EADDRINUSE_NEGATIVE = -98
 
     // Common notification messages.

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingResponseError.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingResponseError.groovy
@@ -1,0 +1,48 @@
+/*
+ * bus/src/main/groovy/com/transroutownish/proto/bus/
+ * UrbanBusRoutingResponseError.groovy
+ * ============================================================================
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.5
+ * ============================================================================
+ * A daemon written in Groovy, designed and intended to be run
+ * as a microservice, implementing a simple urban bus routing prototype.
+ * ============================================================================
+ * Copyright (C) 2023 Radislav (Radicchio) Golubtsov
+ *
+ * (See the LICENSE file at the top of the source tree.)
+ */
+
+package com.transroutownish.proto.bus
+
+/**
+ * The POJO representation of the error message, returning in the response
+ * when one of the <strong>4xx Client Error</strong> section's errors occurred
+ * during processing the request.
+ *
+ * @version 0.1.5
+ * @since   0.1.5
+ */
+class UrbanBusRoutingResponseError {
+    /** The error message. */
+    final String error
+
+    /**
+     * The accessor method for the error message.
+     *
+     * @return The error message.
+     */
+    String getError() {
+        return error
+    }
+
+    /**
+     * The effective constructor for the error message.
+     *
+     * @param _error The error message.
+     */
+    UrbanBusRoutingResponseError(final String _error) {
+        error = _error
+    }
+}
+
+// vim:set nu et ts=4 sw=4:

--- a/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingResponseOk.groovy
+++ b/bus/src/main/groovy/com/transroutownish/proto/bus/UrbanBusRoutingResponseOk.groovy
@@ -1,0 +1,80 @@
+/*
+ * bus/src/main/groovy/com/transroutownish/proto/bus/
+ * UrbanBusRoutingResponseOk.groovy
+ * ============================================================================
+ * Urban bus routing microservice prototype (Groovy port). Version 0.1.5
+ * ============================================================================
+ * A daemon written in Groovy, designed and intended to be run
+ * as a microservice, implementing a simple urban bus routing prototype.
+ * ============================================================================
+ * Copyright (C) 2023 Radislav (Radicchio) Golubtsov
+ *
+ * (See the LICENSE file at the top of the source tree.)
+ */
+
+package com.transroutownish.proto.bus
+
+/**
+ * The POJO representation of successful message, returning in the response.
+ *
+ * @version 0.1.5
+ * @since   0.1.5
+ */
+class UrbanBusRoutingResponseOk {
+    /** The starting bus stop point. */
+    final int from
+
+    /** The ending bus stop point. */
+    final int to
+
+    /**
+     * The indicator of the presence of a direct route
+     * from <code>from</code> to <code>to</code>.
+     */
+    final boolean direct
+
+    /**
+     * The accessor method for the starting bus stop point.
+     *
+     * @return The starting bus stop point.
+     */
+    int getFrom() {
+        return from
+    }
+
+    /**
+     * The accessor method for the ending bus stop point.
+     *
+     * @return The ending bus stop point.
+     */
+    int getTo() {
+        return to
+    }
+
+    /**
+     * The accessor method for the indicator of the presence of a direct route.
+     *
+     * @return The indicator of the presence of a direct route.
+     */
+    boolean isDirect() {
+        return direct
+    }
+
+    /**
+     * The effective constructor for successful message.
+     *
+     * @param _from   The starting bus stop point.
+     * @param _to     The ending   bus stop point.
+     * @param _direct The indicator of the presence of a direct route.
+     */
+    UrbanBusRoutingResponseOk(final int     _from,
+                              final int     _to,
+                              final boolean _direct) {
+
+        from   = _from
+        to     = _to
+        direct = _direct
+    }
+}
+
+// vim:set nu et ts=4 sw=4:


### PR DESCRIPTION
- Introducing the `UrbanBusRoutingResponseError` class that represents an _error message_, returning in the response when one of the client errors (**HTTP 4xx**) occurred during processing the request.
- Sending responses for client errors (**HTTP 4xx**) in **JSON** using the **Jackson** facility.
- Introducing the `UrbanBusRoutingResponseOk` class that represents _successful message_, returning in the response.
- Sending successful responses in **JSON** using the **Jackson** facility (dummy for a while).